### PR TITLE
Feature - Add volumes on feature apps

### DIFF
--- a/features/git-ruby/docker-compose.yml
+++ b/features/git-ruby/docker-compose.yml
@@ -4,5 +4,7 @@ services:
   retest:
     build: .
     volumes:
-      - .:/usr/src/app
+      - git-ruby:/usr/src/app
     command: ruby retest/retest_test.rb
+volumes:
+  git-ruby:

--- a/features/hanami-app/docker-compose.yml
+++ b/features/hanami-app/docker-compose.yml
@@ -4,5 +4,7 @@ services:
   retest:
     build: .
     volumes:
-      - .:/usr/src/app
+      - hanami-app:/usr/src/app
     command: ruby retest/retest_test.rb
+volumes:
+  hanami-app:

--- a/features/rails-app/docker-compose.yml
+++ b/features/rails-app/docker-compose.yml
@@ -4,5 +4,7 @@ services:
   retest:
     build: .
     volumes:
-      - .:/usr/src/app
+      - rails-app:/usr/src/app
     command: ruby retest/retest_test.rb
+volumes:
+  rails-app:

--- a/features/rspec-rails/docker-compose.yml
+++ b/features/rspec-rails/docker-compose.yml
@@ -4,5 +4,7 @@ services:
   retest:
     build: .
     volumes:
-      - .:/usr/src/app
+      - rspec-rails:/usr/src/app
     command: ruby retest/retest_test.rb
+volumes:
+  rspec-rails:

--- a/features/rspec-ruby/docker-compose.yml
+++ b/features/rspec-ruby/docker-compose.yml
@@ -4,5 +4,7 @@ services:
   retest:
     build: .
     volumes:
-      - .:/usr/src/app
+      - rspec-ruby:/usr/src/app
     command: ruby retest/retest_test.rb
+volumes:
+  rspec-ruby:

--- a/features/ruby-app/docker-compose.yml
+++ b/features/ruby-app/docker-compose.yml
@@ -4,5 +4,7 @@ services:
   retest:
     build: .
     volumes:
-      - .:/usr/src/app
+      - ruby-app:/usr/src/app
     command: ruby retest/retest_test.rb
+volumes:
+  ruby-app:

--- a/features/ruby-bare/docker-compose.yml
+++ b/features/ruby-bare/docker-compose.yml
@@ -4,5 +4,7 @@ services:
   retest:
     build: .
     volumes:
-      - .:/usr/src/app
+      - ruby-bare:/usr/src/app
     command: ruby retest/retest_test.rb
+volumes:
+  ruby-bare:


### PR DESCRIPTION
Buildkite agents need the volumes to be defined in the docker-compose file or they would fail to find the appropriate test files to run in the container. I thought I could do without. 