### PR TITLE
Feature - Notification flag

### DIFF
--- a/bin/debug
+++ b/bin/debug
@@ -16,6 +16,10 @@ end
 repository = Retest::Repository.new(files: Retest::VersionControl.files)
 command    = Retest::Command.for_options(options)
 runner     = Retest::Runners.runner_for(command.to_s)
+sounds     = Retest::Sounds.for(options)
+
+sounds.play(:tests_pass)
+runner.add_observer(sounds)
 
 program = Retest::Program.new(
   extension: options.extension,

--- a/exe/retest
+++ b/exe/retest
@@ -14,6 +14,10 @@ end
 repository = Retest::Repository.new(files: Retest::VersionControl.files)
 command    = Retest::Command.for_options(options)
 runner     = Retest::Runners.runner_for(command.to_s)
+sounds     = Retest::Sounds.for(options)
+
+sounds.play(:tests_pass)
+runner.add_observer(sounds)
 
 program = Retest::Program.new(
   extension: options.extension,

--- a/lib/retest.rb
+++ b/lib/retest.rb
@@ -11,6 +11,7 @@ require "retest/setup"
 require "retest/command"
 require "retest/file_system"
 require "retest/program"
+require "retest/sounds"
 
 module Retest
   class Error < StandardError; end

--- a/lib/retest.rb
+++ b/lib/retest.rb
@@ -1,5 +1,6 @@
 require 'listen'
 require 'string/similarity'
+require 'observer'
 
 require "retest/version"
 require "retest/runners"

--- a/lib/retest/options.rb
+++ b/lib/retest/options.rb
@@ -78,7 +78,7 @@ module Retest
 
     flag :notify do
       long "--notify"
-      desc "Play a sound when specs pass or fail"
+      desc "Play a sound when specs pass or fail (macOS only)"
     end
 
     flag :help do

--- a/lib/retest/options.rb
+++ b/lib/retest/options.rb
@@ -76,6 +76,11 @@ module Retest
       desc "Indentify repository setup and runs appropriate command"
     end
 
+    flag :notify do
+      long "--notify"
+      desc "Play a sound when specs pass or fail"
+    end
+
     flag :help do
       short "-h"
       long "--help"
@@ -128,6 +133,10 @@ module Retest
     def auto?
       return true if no_options_passed?
       params[:auto]
+    end
+
+    def notify?
+      params[:notify]
     end
 
     def extension

--- a/lib/retest/runners/change_runner.rb
+++ b/lib/retest/runners/change_runner.rb
@@ -4,7 +4,7 @@ module Retest
       def run(changed_file = nil, repository: nil)
         if changed_file
           puts "Changed File Selected: #{changed_file}"
-          system command.gsub('<changed>', changed_file)
+          system_run command.gsub('<changed>', changed_file)
         else
           puts <<~ERROR
             404 - Test File Not Found

--- a/lib/retest/runners/runner.rb
+++ b/lib/retest/runners/runner.rb
@@ -11,15 +11,21 @@ module Retest
       end
 
       def run(changed_file = nil, repository: nil)
-        system command
+        system_run command
       end
 
       def run_all_tests(tests_string)
         puts "Test File Selected: #{tests_string}"
-        system command.gsub('<test>', tests_string)
+        system_run command.gsub('<test>', tests_string)
       end
 
       def sync(added:, removed:)
+      end
+
+      private
+
+      def system_run(command)
+        system command
       end
     end
   end

--- a/lib/retest/runners/runner.rb
+++ b/lib/retest/runners/runner.rb
@@ -1,6 +1,8 @@
 module Retest
   module Runners
     class Runner
+      include Observable
+
       attr_accessor :command
       def initialize(command)
         @command = command
@@ -25,7 +27,9 @@ module Retest
       private
 
       def system_run(command)
-        system command
+        result = system(command) ? :tests_pass : :tests_fail
+        changed
+        notify_observers(result)
       end
     end
   end

--- a/lib/retest/runners/test_runner.rb
+++ b/lib/retest/runners/test_runner.rb
@@ -14,7 +14,7 @@ module Retest
 
         if cached_test_file
           puts "Test File Selected: #{cached_test_file}"
-          system command.gsub('<test>', cached_test_file)
+          system_run command.gsub('<test>', cached_test_file)
         else
           puts <<~ERROR
             404 - Test File Not Found

--- a/lib/retest/runners/variable_runner.rb
+++ b/lib/retest/runners/variable_runner.rb
@@ -21,7 +21,7 @@ module Retest
 
         FILES
 
-        system command
+        system_run command
           .gsub('<test>', cached_test_file)
           .gsub('<changed>', changed_file)
       end

--- a/lib/retest/sounds.rb
+++ b/lib/retest/sounds.rb
@@ -17,5 +17,6 @@ module Retest
 
       @thread.new { @kernel.system(*args) }
     end
+    alias update play
   end
 end

--- a/lib/retest/sounds.rb
+++ b/lib/retest/sounds.rb
@@ -1,22 +1,36 @@
 module Retest
-  class Sounds
-    def initialize(kernel: Kernel, thread: Thread)
-      @kernel = kernel
-      @thread = thread
+  module Sounds
+    module_function
+
+    def for(options)
+      options.notify? ? MacOS.new : Mute.new
     end
 
-    def play(sound)
-      args = case sound
-      when :tests_fail
-        ['afplay', '/System/Library/Sounds/Sosumi.aiff']
-      when :tests_pass
-        ['afplay', '/System/Library/Sounds/Funk.aiff']
-      else
-        raise ArgumentError.new("No sounds were found for type: #{sound}.")
+    class Mute
+      def play(_)
+      end
+      alias update play
+    end
+
+    class MacOS
+      def initialize(kernel: Kernel, thread: Thread)
+        @kernel = kernel
+        @thread = thread
       end
 
-      @thread.new { @kernel.system(*args) }
+      def play(sound)
+        args = case sound
+        when :tests_fail
+          ['afplay', '/System/Library/Sounds/Sosumi.aiff']
+        when :tests_pass
+          ['afplay', '/System/Library/Sounds/Funk.aiff']
+        else
+          raise ArgumentError.new("No sounds were found for type: #{sound}.")
+        end
+
+        @thread.new { @kernel.system(*args) }
+      end
+      alias update play
     end
-    alias update play
   end
 end

--- a/lib/retest/sounds.rb
+++ b/lib/retest/sounds.rb
@@ -1,0 +1,21 @@
+module Retest
+  class Sounds
+    def initialize(kernel: Kernel, thread: Thread)
+      @kernel = kernel
+      @thread = thread
+    end
+
+    def play(sound)
+      args = case sound
+      when :tests_fail
+        ['afplay', '/System/Library/Sounds/Sosumi.aiff']
+      when :tests_pass
+        ['afplay', '/System/Library/Sounds/Funk.aiff']
+      else
+        raise ArgumentError.new("No sounds were found for type: #{sound}.")
+      end
+
+      @thread.new { @kernel.system(*args) }
+    end
+  end
+end

--- a/test/retest/options/help.txt
+++ b/test/retest/options/help.txt
@@ -17,6 +17,7 @@ Options:
       --ext=regex        Regex of file extensions to listen to (default
                          "\\.rb$")
   -h, --help             Print usage
+      --notify           Play a sound when specs pass or fail
       --rails            Shortcut for a standard Rails setup
       --rake             Shortcut for a standard Rake setup
       --rspec            Shortcut for a standard RSpec setup

--- a/test/retest/options/help.txt
+++ b/test/retest/options/help.txt
@@ -17,7 +17,7 @@ Options:
       --ext=regex        Regex of file extensions to listen to (default
                          "\\.rb$")
   -h, --help             Print usage
-      --notify           Play a sound when specs pass or fail
+      --notify           Play a sound when specs pass or fail (macOS only)
       --rails            Shortcut for a standard Rails setup
       --rake             Shortcut for a standard Rake setup
       --rspec            Shortcut for a standard RSpec setup

--- a/test/retest/options_test.rb
+++ b/test/retest/options_test.rb
@@ -34,5 +34,11 @@ module Retest
     def test_help_text
       assert_equal File.read('test/retest/options/help.txt'), @subject.help
     end
+
+    def test_notify?
+      refute @subject.notify?
+      @subject.args = ["--notify"]
+      assert @subject.notify?
+    end
   end
 end

--- a/test/retest/runners/change_runner_test.rb
+++ b/test/retest/runners/change_runner_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require_relative 'runner_interface'
+require_relative 'observable_runner'
 
 module Retest
   module Runners
@@ -9,6 +10,7 @@ module Retest
       end
 
       include RunnerInterfaceTest
+      include OversableRunnerTests
 
       def test_run_with_no_file_found
         out, _ = capture_subprocess_io { @subject.run }
@@ -23,6 +25,12 @@ module Retest
         out, _ = capture_subprocess_io { @subject.run('file_path.rb') }
 
         assert_match "touch file_path.rb", out
+      end
+
+      private
+
+      def observable_act(subject)
+        subject.run('file_path.rb')
       end
     end
   end

--- a/test/retest/runners/observable_runner.rb
+++ b/test/retest/runners/observable_runner.rb
@@ -1,0 +1,21 @@
+module Retest
+  module Runners
+    module OversableRunnerTests
+      def test_publishes_event_after_running_command
+        observer = MiniTest::Mock.new
+        observer.expect :update, true, [:tests_pass]
+        observer.expect :hash, 1111
+
+        @subject.add_observer(observer)
+
+        capture_subprocess_io { observable_act(@subject) }
+
+        observer.verify
+      end
+
+      def observable_act(subject)
+        raise NotImplementedError.new("#observable_act is not implemented")
+      end
+    end
+  end
+end

--- a/test/retest/runners/observable_runner.rb
+++ b/test/retest/runners/observable_runner.rb
@@ -17,5 +17,11 @@ module Retest
         raise NotImplementedError.new("#observable_act is not implemented")
       end
     end
+
+    module ObserverInterfaceTests
+      def test_observer_interface
+        assert_respond_to @subject, :update
+      end
+    end
   end
 end

--- a/test/retest/runners/runner_interface.rb
+++ b/test/retest/runners/runner_interface.rb
@@ -9,7 +9,7 @@ module Retest
       end
 
       def test_run_accepts_the_right_parameter
-        out, _ = capture_subprocess_io { @subject.run 'some-path.rb', repository: Repository.new }
+        _, _ = capture_subprocess_io { @subject.run 'some-path.rb', repository: Repository.new }
       end
 
       def test_equal

--- a/test/retest/runners/runner_test.rb
+++ b/test/retest/runners/runner_test.rb
@@ -23,7 +23,7 @@ module Retest
       def test_run_all_tests
         runner = Runner.new("echo '<test>'")
 
-        out, _ = capture_subprocess_io { @subject.run_all_tests('file_path.rb file_path_two.rb') }
+        out, _ = capture_subprocess_io { runner.run_all_tests('file_path.rb file_path_two.rb') }
 
         assert_match "file_path.rb file_path_two.rb", out
       end

--- a/test/retest/runners/runner_test.rb
+++ b/test/retest/runners/runner_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require_relative 'runner_interface'
+require_relative 'observable_runner'
 
 module Retest
   module Runners
@@ -9,6 +10,7 @@ module Retest
       end
 
       include RunnerInterfaceTest
+      include OversableRunnerTests
 
       def test_run
         out, _ = capture_subprocess_io { @subject.run('file_path.rb') }
@@ -25,7 +27,16 @@ module Retest
 
         out, _ = capture_subprocess_io { runner.run_all_tests('file_path.rb file_path_two.rb') }
 
-        assert_match "file_path.rb file_path_two.rb", out
+        assert_equal <<~EXPECATIONS, out
+        Test File Selected: file_path.rb file_path_two.rb
+        file_path.rb file_path_two.rb
+        EXPECATIONS
+      end
+
+      private
+
+      def observable_act(subject)
+        subject.run
       end
     end
   end

--- a/test/retest/runners/test_runner_test.rb
+++ b/test/retest/runners/test_runner_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require_relative 'runner_interface'
+require_relative 'observable_runner'
 
 module Retest
   module Runners
@@ -10,6 +11,7 @@ module Retest
       end
 
       include RunnerInterfaceTest
+      include OversableRunnerTests
 
       def test_run_with_no_file_found
         out, _ = capture_subprocess_io { @subject.run nil, repository: @repository}
@@ -51,6 +53,15 @@ module Retest
         @subject.cached_test_file = 'file_path_test.rb'
         @subject.sync(added: 'a.rb', removed:'file_path_test.rb')
         assert_nil @subject.cached_test_file
+      end
+
+      private
+
+      def observable_act(subject)
+        subject.run(
+          'file_path.rb',
+          repository: Repository.new(files: ['file_path_test.rb'])
+        )
       end
     end
   end

--- a/test/retest/runners/variable_runner_test.rb
+++ b/test/retest/runners/variable_runner_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require_relative 'runner_interface'
+require_relative 'observable_runner'
 
 module Retest
   module Runners
@@ -10,6 +11,7 @@ module Retest
       end
 
       include RunnerInterfaceTest
+      include OversableRunnerTests
 
       def test_run_with_no_match
         out, _ = capture_subprocess_io { @subject.run('another_file_path.rb', repository: @repository) }
@@ -51,6 +53,15 @@ module Retest
         @subject.cached_test_file = 'file_path_test.rb'
         @subject.sync(added: 'a.rb', removed:'file_path_test.rb')
         assert_nil @subject.cached_test_file
+      end
+
+      private
+
+      def observable_act(subject)
+        subject.run(
+          'file_path.rb',
+          repository: Repository.new(files: ['file_path_test.rb'])
+        )
       end
     end
   end

--- a/test/retest/sounds/mac_os_test.rb
+++ b/test/retest/sounds/mac_os_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+require_relative './sounds_interface'
+
+module Retest
+  module Sounds
+    class MacOSTests < MiniTest::Test
+      include SoundsInterfaceTests
+
+      def setup
+        @subject = MacOS.new
+      end
+
+      class FakeThread
+        def initialize(&block)
+          block.call
+        end
+      end
+
+      def test_play_tests_pass
+        kernel = MiniTest::Mock.new
+        kernel.expect(:system, true, ['afplay', '/System/Library/Sounds/Funk.aiff'])
+
+        MacOS.new(kernel: kernel, thread: FakeThread).play(:tests_pass)
+
+        kernel.verify
+      end
+
+      def test_play_tests_fail
+        kernel = MiniTest::Mock.new
+        kernel.expect(:system, true, ['afplay', '/System/Library/Sounds/Sosumi.aiff'])
+
+        MacOS.new(kernel: kernel, thread: FakeThread).play(:tests_fail)
+
+        kernel.verify
+      end
+    end
+  end
+end

--- a/test/retest/sounds/mute_test.rb
+++ b/test/retest/sounds/mute_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+require_relative './sounds_interface'
+
+module Retest
+  module Sounds
+    class MuteTests < MiniTest::Test
+      include SoundsInterfaceTests
+
+      def setup
+        @subject = Mute.new
+      end
+
+    end
+  end
+end

--- a/test/retest/sounds/sounds_interface.rb
+++ b/test/retest/sounds/sounds_interface.rb
@@ -1,0 +1,13 @@
+require_relative '../runners/observable_runner'
+
+module Retest
+  module Sounds
+    module SoundsInterfaceTests
+      include Runners::ObserverInterfaceTests
+
+      def test_interface
+        assert_respond_to @subject, :play
+      end
+    end
+  end
+end

--- a/test/retest/sounds_test.rb
+++ b/test/retest/sounds_test.rb
@@ -1,36 +1,10 @@
 require 'test_helper'
-require_relative 'runners/observable_runner'
 
 module Retest
   class SoundsTest < MiniTest::Test
-    include Runners::ObserverInterfaceTests
-
-    def setup
-      @subject = Sounds.new
-    end
-
-    class FakeThread
-      def initialize(&block)
-        block.call
-      end
-    end
-
-    def test_play_tests_pass
-      kernel = MiniTest::Mock.new
-      kernel.expect(:system, true, ['afplay', '/System/Library/Sounds/Funk.aiff'])
-
-      Sounds.new(kernel: kernel, thread: FakeThread).play(:tests_pass)
-
-      kernel.verify
-    end
-
-    def test_play_tests_fail
-      kernel = MiniTest::Mock.new
-      kernel.expect(:system, true, ['afplay', '/System/Library/Sounds/Sosumi.aiff'])
-
-      Sounds.new(kernel: kernel, thread: FakeThread).play(:tests_fail)
-
-      kernel.verify
+    def test_sounds_for
+      assert_instance_of Sounds::MacOS, Sounds.for(Options.new(['--notify']))
+      assert_instance_of Sounds::Mute,  Sounds.for(Options.new([]))
     end
   end
 end

--- a/test/retest/sounds_test.rb
+++ b/test/retest/sounds_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+module Retest
+  class SoundsTest < MiniTest::Test
+    class FakeThread
+      def initialize(&block)
+        block.call
+      end
+    end
+
+    def test_play_tests_pass
+      kernel = MiniTest::Mock.new
+      kernel.expect(:system, true, ['afplay', '/System/Library/Sounds/Funk.aiff'])
+
+      Sounds.new(kernel: kernel, thread: FakeThread).play(:tests_pass)
+
+      kernel.verify
+    end
+
+    def test_play_tests_fail
+      kernel = MiniTest::Mock.new
+      kernel.expect(:system, true, ['afplay', '/System/Library/Sounds/Sosumi.aiff'])
+
+      Sounds.new(kernel: kernel, thread: FakeThread).play(:tests_fail)
+
+      kernel.verify
+    end
+  end
+end

--- a/test/retest/sounds_test.rb
+++ b/test/retest/sounds_test.rb
@@ -1,7 +1,14 @@
 require 'test_helper'
+require_relative 'runners/observable_runner'
 
 module Retest
   class SoundsTest < MiniTest::Test
+    include Runners::ObserverInterfaceTests
+
+    def setup
+      @subject = Sounds.new
+    end
+
     class FakeThread
       def initialize(&block)
         block.call


### PR DESCRIPTION
Fixes #89 

A new flag is available `--notify` which will make a specific sound when tests pass or fail. 
_MacOS only at that point._