### PR TITLE
Udpate help text

### DIFF
--- a/lib/retest/options.rb
+++ b/lib/retest/options.rb
@@ -13,13 +13,18 @@ module Retest
 
       example <<~EOS
       Runs a matching rails test after a file change
-        $ retest 'bundle exec rails test <test>'
+        $ retest 'bin/rails test <test>'
         $ retest --rails
       EOS
 
       example <<~EOS
+      Runs rubocop and matching rails test after a file change
+        $ retest 'rubocop <changed> && bin/rails test <test>'
+      EOS
+
+      example <<~EOS
       Runs all rails tests after a file change
-        $ retest 'bundle exec rails test'
+        $ retest 'bin/rails test'
         $ retest --rails --all
       EOS
 
@@ -51,7 +56,7 @@ module Retest
       optional
       desc <<~EOS
       The test command to rerun when a file changes.
-      Use <test> placeholder to tell retest where to put the matching spec.
+      Use <test> or <changed> placeholders to tell retest where to reference the matching spec or the changed file in the command.
       EOS
     end
 

--- a/test/retest/options/help.txt
+++ b/test/retest/options/help.txt
@@ -4,8 +4,8 @@ Watch a file change and run it matching spec.
 
 Arguments:
   COMMAND  The test command to rerun when a file changes.
-           Use <test> placeholder to tell retest where to put the matching
-           spec.
+           Use <test> or <changed> placeholders to tell retest where to
+           reference the matching spec or the changed file in the command.
            
 
 Options:
@@ -25,11 +25,14 @@ Options:
 
 Examples:
   Runs a matching rails test after a file change
-    $ retest 'bundle exec rails test <test>'
+    $ retest 'bin/rails test <test>'
     $ retest --rails
 
+  Runs rubocop and matching rails test after a file change
+    $ retest 'rubocop <changed> && bin/rails test <test>'
+
   Runs all rails tests after a file change
-    $ retest 'bundle exec rails test'
+    $ retest 'bin/rails test'
     $ retest --rails --all
 
   Runs a hardcoded command after a file change


### PR DESCRIPTION
Fixes #116

We also move from bundle exec rails to bin/rails instead as this is the
recommended command to use on rails apps by default.
