### PR TITLE
Add observer gem as a dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     retest (1.13.0)
       listen (~> 3.9)
-      observer (~> 0.1.0)
+      observer (~> 0.1)
       string-similarity (~> 2.1)
       tty-option (~> 0.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     retest (1.13.0)
       listen (~> 3.9)
+      observer (~> 0.1.0)
       string-similarity (~> 2.1)
       tty-option (~> 0.1)
 
@@ -15,6 +16,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     minitest (5.15.0)
+    observer (0.1.2)
     rake (13.0.6)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)

--- a/retest.gemspec
+++ b/retest.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "string-similarity", ["~> 2.1"]
   spec.add_runtime_dependency "listen", ["~> 3.9"]
   spec.add_runtime_dependency "tty-option", ["~> 0.1"]
-  spec.add_runtime_dependency "observer", ["~> 0.1.0"]
+  spec.add_runtime_dependency "observer", ["~> 0.1"]
 end

--- a/retest.gemspec
+++ b/retest.gemspec
@@ -1,14 +1,14 @@
-require_relative "lib/retest/version"
+require_relative 'lib/retest/version'
 
 Gem::Specification.new do |spec|
-  spec.name = "retest"
-  spec.version = Retest::VERSION
-  spec.authors = ["Alexandre Barret"]
-  spec.email = ["alex@abletech.nz"]
+  spec.name          = "retest"
+  spec.version       = Retest::VERSION
+  spec.authors       = ["Alexandre Barret"]
+  spec.email         = ["alex@abletech.nz"]
 
-  spec.summary = "A simple command line tool to watch file change and run its matching spec."
-  spec.homepage = "https://github.com/AlexB52/retest"
-  spec.license = "MIT"
+  spec.summary       = "A simple command line tool to watch file change and run its matching spec."
+  spec.homepage      = "https://github.com/AlexB52/retest"
+  spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
@@ -19,11 +19,11 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.chdir(File.expand_path("..", __FILE__)) do
+  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir = "exe"
-  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.add_runtime_dependency "string-similarity", ["~> 2.1"]
   spec.add_runtime_dependency "listen", ["~> 3.9"]

--- a/retest.gemspec
+++ b/retest.gemspec
@@ -1,14 +1,14 @@
-require_relative 'lib/retest/version'
+require_relative "lib/retest/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "retest"
-  spec.version       = Retest::VERSION
-  spec.authors       = ["Alexandre Barret"]
-  spec.email         = ["alex@abletech.nz"]
+  spec.name = "retest"
+  spec.version = Retest::VERSION
+  spec.authors = ["Alexandre Barret"]
+  spec.email = ["alex@abletech.nz"]
 
-  spec.summary       = "A simple command line tool to watch file change and run its matching spec."
-  spec.homepage      = "https://github.com/AlexB52/retest"
-  spec.license       = "MIT"
+  spec.summary = "A simple command line tool to watch file change and run its matching spec."
+  spec.homepage = "https://github.com/AlexB52/retest"
+  spec.license = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
@@ -19,13 +19,14 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files = Dir.chdir(File.expand_path("..", __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.add_runtime_dependency "string-similarity", ["~> 2.1"]
   spec.add_runtime_dependency "listen", ["~> 3.9"]
   spec.add_runtime_dependency "tty-option", ["~> 0.1"]
+  spec.add_runtime_dependency "observer", ["~> 0.1.0"]
 end


### PR DESCRIPTION
There is a warning when starting up `retest` that the [observer gem](https://github.com/ruby/observer) will be removed in Ruby 3.4. This PR adds the dependency in.

> /Users/xxx/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/retest-1.13.0/lib/retest.rb:4: warning: observer was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add observer to your Gemfile or gemspec. Also contact author of retest-1.13.0 to add observer into its gemspec.