### PR TITLE
Run all tests on Enter press

### DIFF
--- a/exe/retest
+++ b/exe/retest
@@ -55,7 +55,15 @@ Retest.listen(options) do |modified, added, removed|
   end
 end
 $stdout.puts "Ready to refactor! You can make file changes now"
+$stdout.puts "Press [Enter] to run all tests"
 
-# not blocking
-
-sleep
+loop do
+  input = $stdin.getc
+  if input == "\r" || input == "\n"
+    puts "Enter pressed, sleeping for 3 seconds..."
+    sleep 3
+    puts "Enter done."
+  else
+    puts "You pressed: #{input.inspect}"
+  end
+end

--- a/exe/retest
+++ b/exe/retest
@@ -59,7 +59,6 @@ $stdout.puts "Press [Enter] to run all tests"
 
 run_all_command = Retest::Command.for_options(Retest::Options.new(["--all"]))
 run_all_runner  = Retest::Runners.runner_for(run_all_command.to_s)
-
 loop do
   input = $stdin.getc
   if ["\r", "\n"].include?(input)

--- a/exe/retest
+++ b/exe/retest
@@ -59,11 +59,8 @@ $stdout.puts "Press [Enter] to run all tests"
 
 loop do
   input = $stdin.getc
-  if input == "\r" || input == "\n"
-    puts "Enter pressed, sleeping for 3 seconds..."
-    sleep 3
-    puts "Enter done."
-  else
-    puts "You pressed: #{input.inspect}"
+  if ["\r", "\n"].include?(input)
+    puts "Enter pressed, running all tests"
+    runner.run_all_tests
   end
 end

--- a/exe/retest
+++ b/exe/retest
@@ -57,7 +57,7 @@ end
 $stdout.puts "Ready to refactor! You can make file changes now"
 $stdout.puts "Press [Enter] to run all tests"
 
-run_all_command = Retest::Command.for_options(Retest::Options.new(["--all"]))
+run_all_command = Retest::Command.for_options(Retest::Options.new(["--all"]), quiet: true)
 run_all_runner  = Retest::Runners.runner_for(run_all_command.to_s)
 loop do
   input = $stdin.getc

--- a/exe/retest
+++ b/exe/retest
@@ -57,12 +57,10 @@ end
 $stdout.puts "Ready to refactor! You can make file changes now"
 $stdout.puts "Press [Enter] to run all tests"
 
-run_all_command = Retest::Command.for_options(Retest::Options.new(["--all"]), quiet: true)
-run_all_runner  = Retest::Runners.runner_for(run_all_command.to_s)
 loop do
   input = $stdin.getc
   if ["\r", "\n"].include?(input)
     puts "Enter pressed, running all tests"
-    run_all_runner.run
+    program.run_all
   end
 end

--- a/exe/retest
+++ b/exe/retest
@@ -57,10 +57,13 @@ end
 $stdout.puts "Ready to refactor! You can make file changes now"
 $stdout.puts "Press [Enter] to run all tests"
 
+run_all_command = Retest::Command.for_options(Retest::Options.new(["--all"]))
+run_all_runner  = Retest::Runners.runner_for(run_all_command.to_s)
+
 loop do
   input = $stdin.getc
   if ["\r", "\n"].include?(input)
     puts "Enter pressed, running all tests"
-    runner.run_all_tests
+    run_all_runner.run
   end
 end

--- a/lib/retest/command.rb
+++ b/lib/retest/command.rb
@@ -7,8 +7,8 @@ module Retest
   class Command
     extend Forwardable
 
-    def self.for_options(options)
-      new(options: options).command
+    def self.for_options(options, quiet: false)
+      new(options: options, quiet: quiet).command
     end
 
     def self.for_setup(setup)
@@ -19,10 +19,11 @@ module Retest
     def_delegators :options, :params, :full_suite?, :auto?
 
     attr_accessor :options, :setup
-    def initialize(options: Options.new, setup: Setup.new, stdout: $stdout)
+    def initialize(options: Options.new, setup: Setup.new, stdout: $stdout, quiet: false)
       @options = options
       @setup = setup
       @stdout = stdout
+      @quiet = quiet
     end
 
     def command
@@ -51,7 +52,7 @@ module Retest
     end
 
     def default_command
-      @stdout.puts "Setup identified: [#{type.upcase}]. Using command: '#{setup_command}'"
+      @stdout.puts "Setup identified: [#{type.upcase}]. Using command: '#{setup_command}'" unless @quiet
       setup_command
     end
 

--- a/lib/retest/command/rails.rb
+++ b/lib/retest/command/rails.rb
@@ -10,7 +10,7 @@ module Retest
 
       def to_s
         return "#{root_command} <test>" unless all
-        root_command
+        all_command
       end
 
       def format_batch(*files)
@@ -20,6 +20,12 @@ module Retest
       private
 
       def root_command
+        return 'bin/rails test' if file_system.exist? 'bin/rails'
+
+        'bundle exec rails test'
+      end
+
+      def all_command
         return 'bin/rails test:all' if file_system.exist? 'bin/rails'
 
         'bundle exec rails test:all'

--- a/lib/retest/command/rails.rb
+++ b/lib/retest/command/rails.rb
@@ -10,7 +10,7 @@ module Retest
 
       def to_s
         return "#{root_command} <test>" unless all
-        all_command
+        "#{root_command}:all"
       end
 
       def format_batch(*files)
@@ -23,12 +23,6 @@ module Retest
         return 'bin/rails test' if file_system.exist? 'bin/rails'
 
         'bundle exec rails test'
-      end
-
-      def all_command
-        return 'bin/rails test:all' if file_system.exist? 'bin/rails'
-
-        'bundle exec rails test:all'
       end
     end
   end

--- a/lib/retest/command/rails.rb
+++ b/lib/retest/command/rails.rb
@@ -20,9 +20,9 @@ module Retest
       private
 
       def root_command
-        return 'bin/rails test' if file_system.exist? 'bin/rails'
+        return 'bin/rails test:all' if file_system.exist? 'bin/rails'
 
-        'bundle exec rails test'
+        'bundle exec rails test:all'
       end
     end
   end

--- a/lib/retest/program.rb
+++ b/lib/retest/program.rb
@@ -1,10 +1,13 @@
 module Retest
   class Program
-    attr_accessor :runner, :repository, :command
+    attr_accessor :runner, :repository, :command, :all_runner
     def initialize(runner: nil, repository: nil, command: nil)
       @runner = runner
       @repository = repository
       @command = command
+      @all_runner = Retest::Runners.runner_for(
+        Retest::Command.for_options(Retest::Options.new(["--all"]), quiet: true).to_s
+      )
     end
 
     def run(modified, added, removed)
@@ -13,6 +16,12 @@ module Retest
       system('clear 2>/dev/null') || system('cls 2>/dev/null')
 
       runner.run (modified + added).first, repository: repository
+    end
+
+    def run_all
+      system('clear 2>/dev/null') || system('cls 2>/dev/null')
+
+      all_runner.run
     end
 
     def diff(branch)

--- a/test/retest/command/auto_flag.rb
+++ b/test/retest/command/auto_flag.rb
@@ -88,9 +88,9 @@ module Retest
     def test_for_rails_setup
       @setup.type = :rails
 
-      assert_equal 'bundle exec rails test', @subject.command.to_s
+      assert_equal 'bundle exec rails test:all', @subject.command.to_s
       assert_equal(<<~OUTPUT, output)
-        Setup identified: [RAILS]. Using command: 'bundle exec rails test'
+        Setup identified: [RAILS]. Using command: 'bundle exec rails test:all'
       OUTPUT
     end
 

--- a/test/retest/command/rails_test.rb
+++ b/test/retest/command/rails_test.rb
@@ -11,13 +11,13 @@ module Retest
       include CommandInterface
 
       def test_to_s
-        assert_equal 'bin/rails test',                Rails.new(all: true, file_system: FakeFS.new(['bin/rails'])).to_s
-        assert_equal 'bundle exec rails test',        Rails.new(all: true, file_system: FakeFS.new([])).to_s
+        assert_equal 'bin/rails test:all',            Rails.new(all: true, file_system: FakeFS.new(['bin/rails'])).to_s
+        assert_equal 'bundle exec rails test:all',    Rails.new(all: true, file_system: FakeFS.new([])).to_s
         assert_equal 'bin/rails test <test>',         Rails.new(all: false, file_system: FakeFS.new(['bin/rails'])).to_s
         assert_equal 'bundle exec rails test <test>', Rails.new(all: false, file_system: FakeFS.new([])).to_s
         # take into account gem repository which doesn't have a bin file
         assert_equal 'bundle exec rails test <test>', Rails.new(all: false).to_s
-        assert_equal 'bundle exec rails test',        Rails.new(all: true).to_s
+        assert_equal 'bundle exec rails test:all',    Rails.new(all: true).to_s
       end
 
       def test_format_with_one_file

--- a/test/retest/command_test.rb
+++ b/test/retest/command_test.rb
@@ -37,7 +37,7 @@ module Retest
       assert_equal 'bundle exec rspec', @subject.command.to_s
 
       @subject.options = Options.new(['--rails', '--all'])
-      assert_equal 'bundle exec rails test', @subject.command.to_s
+      assert_equal 'bundle exec rails test:all', @subject.command.to_s
 
       @subject.options = Options.new(['--rake', '--all'])
       assert_equal 'bundle exec rake test', @subject.command.to_s


### PR DESCRIPTION
I'm looking for a replacement for Guard and I really like retest. The thing I miss is being able to run all tests with just a single keypress when desired. So here it goes.

Further this PR includes a change to the default Rails command for running all tests. Currently it would not include the system tests, when it's invoked with just "rails test". To really include all tests, including system tests, "rails test:all" needs to be used.