### PR TITLE
Set Runner last command on initialization

### DIFF
--- a/features/rails-app/retest/retest_test.rb
+++ b/features/rails-app/retest/retest_test.rb
@@ -22,6 +22,12 @@ class MatchingTestsCommandTest < Minitest::Test
       Launching Retest...
       Ready to refactor! You can make file changes now
     EXPECTED
+
+    write_input("\n") # Trigger last command when no command was run
+
+    assert_output_matches <<~EXPECTED
+      Error - Not enough information to run a command. Please trigger a run first.
+    EXPECTED
   end
 
   def test_modify_a_file
@@ -53,6 +59,10 @@ class AllTestsCommandTest < Minitest::Test
       Launching Retest...
       Ready to refactor! You can make file changes now
     EXPECTED
+
+    write_input("\n") # Trigger all command when no command was run
+
+    assert_output_matches "8 runs, 10 assertions, 0 failures, 0 errors, 0 skips"
   end
 
   def test_modify_a_file

--- a/features/rspec-rails/retest/retest_test.rb
+++ b/features/rspec-rails/retest/retest_test.rb
@@ -22,6 +22,12 @@ class MatchingTestsCommandTest < Minitest::Test
       Launching Retest...
       Ready to refactor! You can make file changes now
     EXPECTED
+
+    write_input("\n") # Trigger last command when no command was run
+
+    assert_output_matches <<~EXPECTED
+      Error - Not enough information to run a command. Please trigger a run first.
+    EXPECTED
   end
 
   def test_modify_a_file
@@ -53,6 +59,10 @@ class AllTestsCommandTest < Minitest::Test
       Launching Retest...
       Ready to refactor! You can make file changes now
     EXPECTED
+
+    write_input("\n") # Trigger all command when no command was run
+
+    assert_output_matches "9 examples, 0 failures"
   end
 
   def test_modify_a_file

--- a/features/ruby-app/retest/retest_test.rb
+++ b/features/ruby-app/retest/retest_test.rb
@@ -24,6 +24,12 @@ class TestListenWatcher <  Minitest::Test
       Launching Retest...
       Ready to refactor! You can make file changes now
     EXPECTED
+
+    write_input("\n") # Trigger last command when no command was run
+
+    assert_output_matches <<~EXPECTED
+      Error - Not enough information to run a command. Please trigger a run first.
+    EXPECTED
   end
 end
 

--- a/lib/retest/command/base.rb
+++ b/lib/retest/command/base.rb
@@ -13,6 +13,10 @@ module Retest
         self.class.new(**{ all: all, file_system: file_system, command: command }.merge(params))
       end
 
+      def hardcoded?
+        !has_changed? && !has_test?
+      end
+
       def has_changed?
         to_s.include?('<changed>')
       end

--- a/lib/retest/runner.rb
+++ b/lib/retest/runner.rb
@@ -12,15 +12,22 @@ module Retest
     def initialize(command, stdout: $stdout)
       @stdout  = stdout
       @command = command
+      if command.hardcoded?
+        self.last_command = command.to_s
+      end
     end
 
     def run_last_command
+      unless last_command
+        return log('Error - Not enough information to trigger a run')
+      end
+
       system_run last_command
     end
 
     def run(changed_files: [], test_files: [])
       self.last_command = format_instruction(changed_files: changed_files, test_files: test_files)
-      system_run last_command
+      run_last_command
     rescue FileNotFound => e
       log("FileNotFound - #{e.message}")
     rescue Command::MultipleTestsNotSupported => e
@@ -29,7 +36,7 @@ module Retest
 
     def run_all
       self.last_command = command.clone(all: true).to_s
-      system_run last_command
+      run_last_command
     end
 
     def format_instruction(changed_files: [], test_files: [])
@@ -76,12 +83,6 @@ module Retest
     end
 
     private
-
-    def print_test_file_not_found
-      log(<<~ERROR)
-        FileNotFound - Retest could not find a matching test file to run.
-      ERROR
-    end
 
     def system_run(command)
       log("\n")

--- a/lib/retest/runner.rb
+++ b/lib/retest/runner.rb
@@ -19,7 +19,7 @@ module Retest
 
     def run_last_command
       unless last_command
-        return log('Error - Not enough information to trigger a run')
+        return log('Error - Not enough information to run a command. Please trigger a run first.')
       end
 
       system_run last_command

--- a/test/retest/runner_test.rb
+++ b/test/retest/runner_test.rb
@@ -119,7 +119,7 @@ module Retest
 
         assert_equal '', out
         assert_equal(<<~EXPECTED, output)
-          Error - Not enough information to trigger a run
+          Error - Not enough information to run a command. Please trigger a run first.
         EXPECTED
       end
     end
@@ -155,7 +155,7 @@ module Retest
 
         assert_equal '', out
         assert_equal(<<~EXPECTED, output)
-          Error - Not enough information to trigger a run
+          Error - Not enough information to run a command. Please trigger a run first.
         EXPECTED
       end
     end
@@ -201,7 +201,7 @@ module Retest
 
         assert_equal '', out
         assert_equal(<<~EXPECTED, output)
-          Error - Not enough information to trigger a run
+          Error - Not enough information to run a command. Please trigger a run first.
         EXPECTED
       end
 


### PR DESCRIPTION
Fixes #240 

Sets runner's last command during initialisation when the command is runnable (e.g. with no placeholders)