### PR TITLE
Claude Code - force batch

### DIFF
--- a/lib/retest.rb
+++ b/lib/retest.rb
@@ -14,6 +14,7 @@ require "retest/program"
 require "retest/prompt"
 require "retest/sounds"
 require "retest/watcher"
+require "retest/output"
 
 module Retest
   class Error < StandardError; end

--- a/lib/retest/matching_options.rb
+++ b/lib/retest/matching_options.rb
@@ -17,15 +17,7 @@ module Retest
 
     def filtered_results
       if path.test?(test_directories: test_directories)
-        # If input is a test file, find exact or partial matches
-        exact_match = files.find { |file| file == path.to_s }
-        if exact_match
-          [Path.new(exact_match)]
-        else
-          # Find files that end with this test file name
-          partial_matches = files.select { |file| file.end_with?(path.to_s) }
-          partial_matches.empty? ? [] : partial_matches.map { |file| Path.new(file) }
-        end
+        find_test_file_matches
       elsif (screened_tests = screen_namespaces(possible_tests)).any?
         screened_tests
       else
@@ -34,6 +26,22 @@ module Retest
     end
 
     private
+
+    def find_test_file_matches
+      exact_match = find_exact_match
+      return [Path.new(exact_match)] if exact_match
+      
+      find_partial_matches
+    end
+
+    def find_exact_match
+      files.find { |file| file == path.to_s }
+    end
+
+    def find_partial_matches
+      partial_matches = files.select { |file| file.end_with?(path.to_s) }
+      partial_matches.empty? ? [] : partial_matches.map { |file| Path.new(file) }
+    end
 
     def possible_tests
       @possible_tests ||= files

--- a/lib/retest/matching_options.rb
+++ b/lib/retest/matching_options.rb
@@ -17,7 +17,15 @@ module Retest
 
     def filtered_results
       if path.test?(test_directories: test_directories)
-        [path]
+        # If input is a test file, find exact or partial matches
+        exact_match = files.find { |file| file == path.to_s }
+        if exact_match
+          [Path.new(exact_match)]
+        else
+          # Find files that end with this test file name
+          partial_matches = files.select { |file| file.end_with?(path.to_s) }
+          partial_matches.empty? ? [] : partial_matches.map { |file| Path.new(file) }
+        end
       elsif (screened_tests = screen_namespaces(possible_tests)).any?
         screened_tests
       else

--- a/lib/retest/output.rb
+++ b/lib/retest/output.rb
@@ -1,0 +1,20 @@
+module Retest
+  class Output
+    def self.force_batch_failures(failed_paths, out: nil)
+      return nil if failed_paths.nil? || failed_paths.empty?
+      
+      output = <<~OUTPUT
+
+Retest could not find matching tests for these inputs:
+#{failed_paths.map { |path| "  - #{path}" }.join("\n")}
+
+      OUTPUT
+      
+      if out
+        out.write(output)
+      else
+        output
+      end
+    end
+  end
+end

--- a/lib/retest/output.rb
+++ b/lib/retest/output.rb
@@ -1,20 +1,31 @@
 module Retest
   class Output
     def self.force_batch_failures(failed_paths, out: nil)
-      return nil if failed_paths.nil? || failed_paths.empty?
+      return nil if no_failures?(failed_paths)
       
-      output = <<~OUTPUT
+      output = format_failures_message(failed_paths)
+      deliver_output(output, out)
+    end
+
+    private_class_method def self.no_failures?(failed_paths)
+      failed_paths.nil? || failed_paths.empty?
+    end
+
+    private_class_method def self.format_failures_message(failed_paths)
+      <<~OUTPUT
 
 Retest could not find matching tests for these inputs:
-#{failed_paths.map { |path| "  - #{path}" }.join("\n")}
+#{format_failed_paths(failed_paths)}
 
       OUTPUT
-      
-      if out
-        out.write(output)
-      else
-        output
-      end
+    end
+
+    private_class_method def self.format_failed_paths(failed_paths)
+      failed_paths.map { |path| "  - #{path}" }.join("\n")
+    end
+
+    private_class_method def self.deliver_output(output, out)
+      out ? out.write(output) : output
     end
   end
 end

--- a/lib/retest/program.rb
+++ b/lib/retest/program.rb
@@ -21,11 +21,9 @@ module Retest
     end
 
     def force_batch(input)
-      paths = input.strip.split("\n").map(&:strip).reject(&:empty?)
-      test_results = repository.search_tests(paths)
-      valid_tests = test_results.values.compact.uniq.sort
-      force_selection(valid_tests)
-      runner.run(test_files: valid_tests)
+      paths = parse_batch_input(input)
+      test_files = find_test_files_for_paths(paths)
+      execute_batch_selection(test_files)
     end
 
     def run(file, force_run: false)
@@ -64,6 +62,21 @@ module Retest
 
     def clear_terminal
       system('clear 2>/dev/null') || system('cls 2>/dev/null')
+    end
+
+    private
+
+    def parse_batch_input(input)
+      input.strip.split("\n").map(&:strip).reject(&:empty?)
+    end
+
+    def find_test_files_for_paths(paths)
+      repository.search_tests(paths).values.compact.uniq.sort
+    end
+
+    def execute_batch_selection(test_files)
+      force_selection(test_files)
+      runner.run(test_files: test_files)
     end
   end
 end

--- a/lib/retest/program.rb
+++ b/lib/retest/program.rb
@@ -20,6 +20,14 @@ module Retest
       initialize_forced_selection([])
     end
 
+    def force_batch(input)
+      paths = input.strip.split("\n").map(&:strip).reject(&:empty?)
+      test_results = repository.search_tests(paths)
+      valid_tests = test_results.values.compact.uniq.sort
+      force_selection(valid_tests)
+      runner.run(test_files: valid_tests)
+    end
+
     def run(file, force_run: false)
       if paused? && !force_run
         @stdout.puts "Main program paused. Please resume program first."

--- a/lib/retest/repository.rb
+++ b/lib/retest/repository.rb
@@ -32,11 +32,7 @@ module Retest
     end
 
     def search_tests(paths)
-      result = {}
-      paths.each do |path|
-        result[path] = find_test(path)
-      end
-      result
+      paths.to_h { |path| [path, find_test(path)] }
     end
 
     def test_files

--- a/lib/retest/repository.rb
+++ b/lib/retest/repository.rb
@@ -31,6 +31,14 @@ module Retest
         .sort
     end
 
+    def search_tests(paths)
+      result = {}
+      paths.each do |path|
+        result[path] = find_test(path)
+      end
+      result
+    end
+
     def test_files
       files.select { |file| MatchingOptions::Path.new(file).test? }
     end

--- a/test/retest/matching_options_test.rb
+++ b/test/retest/matching_options_test.rb
@@ -36,7 +36,7 @@ module Retest
     def test_return_test_file_when_changed
       file_changed = expected = 'test/models/schedule/test_holdings.rb'
 
-      assert_equal [expected], MatchingOptions.for(file_changed, files: [])
+      assert_equal [expected], MatchingOptions.for(file_changed, files: ['test/models/schedule/test_holdings.rb'])
     end
 
     def test_multiple_matches
@@ -84,7 +84,7 @@ module Retest
     def test_return_test_file_when_changed
       file_changed = expected = 'test/models/schedule/holdings_test.rb'
 
-      assert_equal [expected], MatchingOptions.for(file_changed, files: [])
+      assert_equal [expected], MatchingOptions.for(file_changed, files: ['test/models/schedule/holdings_test.rb'])
     end
 
     def test_multiple_matches_on_hanami_setup
@@ -121,7 +121,7 @@ module Retest
     end
   end
 
-  class MultiplePatternTest < Minitest::Test
+  class TestMultiplePattern < Minitest::Test
     def test_no_default_pattern_match
       files = %w(
         lib/active_record/fixtures.rb
@@ -163,6 +163,49 @@ module Retest
       )
 
       assert_equal files, MatchingOptions.for('lib/holdings.rb', files: files, limit: 8)
+    end
+  end
+
+  class TestMatchingTestInputs < Minitest::Test
+    def test_exact_test_match
+      files = %w(
+        spec_holdings.rb
+        test_holdings.rb
+        holdings_spec.rb
+        holdings_test.rb
+        spec/holdings_spec.rb
+        spec/holdings_test.rb
+        test/holdings_spec.rb
+        test/holdings_test.rb
+      )
+
+      assert_equal ['spec/holdings_test.rb'], MatchingOptions.for('spec/holdings_test.rb', files: files)
+      assert_equal ['holdings_spec.rb'], MatchingOptions.for('holdings_spec.rb', files: files)
+    end
+
+    def test_unknonw_test_paths
+      files = %w(
+        spec_holdings.rb
+        test_holdings.rb
+        holdings_spec.rb
+        holdings_test.rb
+        spec/holdings_spec.rb
+        spec/holdings_test.rb
+        test/holdings_spec.rb
+        test/holdings_test.rb
+      )
+
+      assert_equal [], MatchingOptions.for('spec/repository_test.rb', files: files)
+    end
+
+    def test_multiple_possible_test_matches
+      files = %w(
+        spec/holdings_spec.rb
+        test/holdings_spec.rb
+        test/portfolio/holdings_spec.rb
+      )
+
+      assert_equal files, MatchingOptions.for('holdings_spec.rb', files: files)
     end
   end
 end

--- a/test/retest/output_test.rb
+++ b/test/retest/output_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+module Retest
+  class TestForceBatchFailures < Minitest::Test
+    def test_without_stdout
+      assert_equal <<~OUTPUT, Output.force_batch_failures(%w[hello.rb test/unknown.rb lib.rb Gemfile])
+
+        Retest could not find matching tests for these inputs:
+          - hello.rb
+          - test/unknown.rb
+          - lib.rb
+          - Gemfile
+
+      OUTPUT
+    end
+
+    def test_with_empty_paths
+      assert_nil Output.force_batch_failures([])
+      assert_nil Output.force_batch_failures(nil)
+    end
+
+    def test_with_stdout
+      stdout = StringIO.new
+      Output.force_batch_failures(%w[hello.rb test/unknown.rb lib.rb Gemfile], out: stdout)
+
+      assert_equal <<~OUTPUT, stdout.tap(&:rewind).read
+
+        Retest could not find matching tests for these inputs:
+          - hello.rb
+          - test/unknown.rb
+          - lib.rb
+          - Gemfile
+
+      OUTPUT
+    end
+  end
+end

--- a/test/retest/program_test.rb
+++ b/test/retest/program_test.rb
@@ -2,6 +2,137 @@ require 'test_helper'
 
 module Retest
   class ProgramTest < Minitest::Test
+    class ForceBatchTest < Minitest::Test
+      def setup
+        @repository = Repository.new(files: %w[
+          test/retest/command/hardcoded_test.rb
+          test/retest/command/rails_test.rb
+          test/retest/command/rake_test.rb
+          test/retest/command/rspec_test.rb
+          test/retest/command/ruby_test.rb
+          test/retest/command_test.rb
+          test/retest/file_system_test.rb
+          test/retest/program_test.rb
+          test/retest/prompt_test.rb
+          test/retest/repository_test.rb
+          test/retest/runner_test.rb
+          test/retest/setup_test.rb
+        ])
+        @runner = EmptyRunner.new
+        @subject = Program.new(runner: @runner, repository: @repository, stdout: StringIO.new)
+      end
+
+      def check_runner_runs_files(files, journal: @runner.journal)
+        assert_equal [
+          {
+            method: :run,
+            args: [],
+            kwargs: { test_files: files }
+          }
+        ], journal
+      end
+
+      def test_program_forced_selection_enabled
+        @subject.force_batch(<<~INPUT)
+          test/retest/command/ruby_test.rb
+          test/retest/file_system_test.rb
+        INPUT
+
+        assert @subject.forced_selection?
+        assert_equal %w[
+          test/retest/command/ruby_test.rb
+          test/retest/file_system_test.rb
+        ], @subject.selected_test_files
+      end
+
+      def test_happy_path_known_test_files
+        @subject.force_batch(<<~INPUT)
+          test/retest/command/ruby_test.rb
+          test/retest/command_test.rb
+          test/retest/file_system_test.rb
+          test/retest/program_test.rb
+          test/retest/prompt_test.rb
+        INPUT
+
+        check_runner_runs_files(%w[
+          test/retest/command/ruby_test.rb
+          test/retest/command_test.rb
+          test/retest/file_system_test.rb
+          test/retest/program_test.rb
+          test/retest/prompt_test.rb
+        ])
+      end
+
+      def test_unknown_test_paths
+        @subject.force_batch(<<~INPUT)
+          test/retest/command_test.rb
+          test/retest/file_system_test.rb
+          test/retest/UNKNOWN_TEST.rb
+        INPUT
+
+        check_runner_runs_files(%w[
+          test/retest/command_test.rb
+          test/retest/file_system_test.rb
+        ])
+      end
+
+      def test_incomplete_test_paths
+        @subject.force_batch(<<~INPUT)
+          test/retest/command_test.rb
+          file_system_test.rb
+        INPUT
+
+        check_runner_runs_files(%w[
+          test/retest/command_test.rb
+          test/retest/file_system_test.rb
+        ])
+      end
+
+      def test_multiple_same_test_paths
+        @subject.force_batch(<<~INPUT)
+          test/retest/command_test.rb
+          test/retest/command_test.rb
+          test/retest/file_system_test.rb
+          retest/file_system_test.rb
+          file_system_test.rb
+        INPUT
+
+        expected_test_files = %w[
+          test/retest/command_test.rb
+          test/retest/file_system_test.rb
+        ]
+
+        check_runner_runs_files(expected_test_files)
+      end
+
+      def test_changed_files_identification
+        # Match normal ruby files and select their matching test files
+        @subject.force_batch(<<~INPUT)
+          command.rb
+          lib/retest/file_system.rb
+          command/rake.rb
+          command/rake_test.rb
+          command/rspec.rb
+          lib/retest/special_unknown_folder/runner.rb
+        INPUT
+
+        expected_test_files = %w[
+          test/retest/command/rake_test.rb
+          test/retest/command/rspec_test.rb
+          test/retest/command_test.rb
+          test/retest/file_system_test.rb
+          test/retest/runner_test.rb
+        ]
+
+        check_runner_runs_files(expected_test_files)
+      end
+
+      def test_numbered_test_paths
+        # Check support for numbered test paths
+        skip
+      end
+    end
+
     class PauseTest < Minitest::Test
       def setup
         @subject = Program.new(repository: Repository.new, stdout: StringIO.new)

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -13,13 +13,28 @@ module Retest
     end
   end
 
-  class RaisingRunner
+  class EmptyRunner
+    attr_reader :journal
     def initialize
+      @journal = []
     end
 
-    def sync(added:, removed:)
+    def sync(*args, **kwargs)
+      add_to_journal(__method__, args: args, kwargs: kwargs)
     end
 
+    def run(*args, **kwargs)
+      add_to_journal(__method__, args: args, kwargs: kwargs)
+    end
+
+    private
+
+    def add_to_journal(method, args:, kwargs:)
+      @journal << { method: method, args: args, kwargs: kwargs }
+    end
+  end
+
+  class RaisingRunner < EmptyRunner
     def run(file, repository:)
       raise MethodCallError, "#{__method__} should not be called"
     end


### PR DESCRIPTION
Force batch implementation done by a first pass of Claude code

## Prompt was

> I have a bunch of tests currently failing while running "rake test". This is a new feature. I want you to implement the feature by making all the specs pass. You're not allowed to run ad-hoc ruby commands only rake tests to see the failures. Make one pass for now.

Results: 3553b9caaa42b1f67903b8d2cbf668e532bb7b3f

Focused on implementing the feauture and getting tests pass

## Second prompt

> Now refactor the code you write in the spirit of red green refactor. You're allowed to run rake test to help you out.

Results: dc8d713b57d99cdb823a52309278a1b4e0ea05ff

Only extracting private methods to make code shorter.  Code looks worse. No understanding of what could be reused elsewhere.

One tip I didn't know about, which is pretty cool
```ruby
paths.to_h { |path| [path, find_test(path)] }
```

## Third Prompt

> Checkout the force-batch branch locally and check exe/retest file. You're allowed to look at the rest of the code to get an insight. Feel free to tell me what were the tests I failed to write. Also feel free to review the code I wrote to implement the feature.

Result:

```
Code Review Analysis

  Your Implementation vs Mine

  Your force_batch implementation is significantly better:

  1. Better input parsing: You use multiline_input.split(/\s+/) which handles any whitespace
  (spaces, tabs, newlines), while mine used split("\n").map(&:strip) which assumed line-based
  input.
  2. Superior error handling: You partition into failures/successes and show user feedback for both
   cases:
    - Shows failures with Output.force_batch_failures
    - Shows "No test files found" when no matches
    - Only runs tests when there are actual successes
  3. Better Output module design: You made it a module with module_function rather than a class,
  which is more appropriate for utility functions.
  4. Cleaner repository logic: Your search_tests filters to only .rb files upfront and uses
  result[path] ||= for duplicate handling.
  5. More intuitive CLI integration: Using prompt.multiline("Enter list of test files to run").join
   provides a natural multi-line input experience.

  Tests You Failed to Write

  Based on my analysis, here are the missing tests:

  1. CLI Integration Tests: No tests for the actual 'fb'/'force batch' command in the interactive
  loop
  2. Multi-line Input Parsing: No tests for whitespace-separated input parsing (/\s+/ splitting)
  3. User Feedback Tests: No tests verifying the "No test files found" message
  4. TTY::Prompt Integration: No tests for the actual CLI prompt integration
  5. Edge Cases:
    - Mixed valid/invalid files with proper feedback
    - All invalid files (should only show errors, not run)
    - Empty input handling
    - Non-.rb files being filtered out

  Your Code Review

  Strengths of your implementation:
  - More robust input parsing
  - Better separation of concerns (failures vs successes)
  - Proper user feedback for all scenarios
  - More appropriate module structure for Output
  - Cleaner repository filtering logic

  Potential improvements:
  - Could add integration tests for CLI commands
  - The help text doesn't mention the 'fb' command
  - Could validate the TTY::Prompt integration with tests

  My Learning

  Your implementation taught me:
  1. Better API design: Partitioning results is cleaner than my approach
  2. User experience: Always provide feedback for failed operations
  3. Ruby idioms: module_function for utility modules, ||= for duplicate handling
  4. Input parsing: Using regex for flexible whitespace handling

  Your refactoring was excellent and showed a more mature understanding of the domain requirements
  than my test-driven implementation!
```