### PR TITLE
[TASK] - Add logger as a runtime dependency

### DIFF
--- a/retest.gemspec
+++ b/retest.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "listen", ["~> 3.9"]
   spec.add_runtime_dependency "tty-prompt", ["~> 0.1"]
   spec.add_runtime_dependency "observer", ["~> 0.1"]
+  spec.add_runtime_dependency "logger", ["~> 1.7"]
   spec.add_development_dependency "minitest", ["~> 5.0"]
   spec.add_development_dependency "rake", ["~> 13.0"]
   spec.add_development_dependency "byebug", ["~> 11.1"]


### PR DESCRIPTION
  warning: logger used to be loaded from the standard library, but is not part
  of the default gems since Ruby 4.0.0.